### PR TITLE
Improve config provider verification

### DIFF
--- a/src/knockout-select2.js
+++ b/src/knockout-select2.js
@@ -9,7 +9,7 @@
     'use strict';
 
     var bindingName = 'select2';
-    if (module && module.config().name) {
+    if (module && module.config() && module.config().name) {
         bindingName = module.config().name;
     }
     


### PR DESCRIPTION
SystemJS loader returns undefined of module.config() that throw this exception:
Uncaught (in promise) TypeError: Cannot read property 'name' of undefined