### PR TITLE
module.config is not a function error in SystemJS

### DIFF
--- a/src/knockout-select2.js
+++ b/src/knockout-select2.js
@@ -9,7 +9,7 @@
     'use strict';
 
     var bindingName = 'select2';
-    if (module && module.config() && module.config().name) {
+    if (module && module.config && module.config() && module.config().name) {
         bindingName = module.config().name;
     }
 


### PR DESCRIPTION
Fixes module.config is not a function error in SystemJS in production mode.